### PR TITLE
Add UTF-8 testing with PKI functions

### DIFF
--- a/ssl_pki/tests/test_ssl_pki.py
+++ b/ssl_pki/tests/test_ssl_pki.py
@@ -1128,6 +1128,39 @@ class TestPkiUtils(PkiTestCase):
             self.base_url,
             relative_to_absolute_url(self.base_url))
 
+    def test_utf8_compat(self):
+        # Test all functions work with utf8 strings
+        # encode() will encode strings as utf8 by default
+        self.assertTrue(has_pki_prefix(self.pki_url.encode()))
+
+        self.assertTrue(has_proxy_prefix(self.proxy_url.encode()))
+
+        self.assertEqual(self.pki_url,
+                         pki_route(self.base_url.encode()))
+
+        self.assertEqual(self.proxy_url,
+                         proxy_route(self.base_url.encode()))
+
+        self.assertEqual(self.base_url,
+                         pki_route_reverse(self.pki_url.encode()))
+
+        self.assertEqual(self.base_url,
+                         proxy_route_reverse(self.base_url.encode()))
+
+        self.assertEqual(self.proxy_url,
+                         pki_to_proxy_route(self.pki_url.encode()))
+
+        self.assertTrue(
+            protocol_relative_url(self.protocol_relative_url.encode()))
+
+        self.assertEqual(
+            self.base_url,
+            protocol_relative_to_scheme(self.protocol_relative_url.encode()))
+
+        self.assertEqual(
+            self.base_url,
+            relative_to_absolute_url(self.protocol_relative_url.encode()))
+
     def test_url_formatting(self):
         self.assertEqual(self.ep_root.lower(),
                          normalize_hostname(self.ep_root))


### PR DESCRIPTION
Updates PKI unit tests to test for UTF-8 compatibility.

As far as I can tell it appears as though most tests were already using UTF-8 strings and only utils functions weren't being tested with UTF-8 encoded strings. Added a test for all utils functions using the same strings, but UTF-8 encoded.